### PR TITLE
feat(ime): 改用左 Option 按住说话触发豆包语音输入

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,23 +77,33 @@ chmod +x ./install.sh
 ./install.sh --force
 ```
 
+## 前置配置：豆包语音输入「长按模式」
+
+> 适配豆包输入法 macOS 版本 **0.9.1**。
+
+脚本依赖豆包的「长按说话」快捷键，请先在豆包输入法中确认：
+
+1. 打开豆包输入法设置 → `语音输入`。
+2. 在「快捷键」中找到 **长按模式**（按住说话，松手结束）。
+3. 确认其快捷键绑定为 **左 ⌘（左 Command）**。
+
+脚本正是通过"按住左 Command"来对接这个长按模式，所以这一项必须设为左 ⌘。
+
 ## 安装后怎么用
 
 1. 打开 Hammerspoon。
 2. 第一次运行时，为 Hammerspoon 授予 macOS 的“辅助功能”权限。
 3. 在 Hammerspoon 菜单栏图标中点击 `Reload Config`。
-4. 默认按住并松开右侧 `Command` 键。
-5. 脚本会自动切换到豆包输入法、触发语音输入，并在稍后恢复你原本的输入法。
+4. **按住左侧 `Option` 键说话，说完松开。**
+5. 脚本会自动切换到豆包输入法、按住左 `Command` 开始录音，松开后结束录音，并在稍后恢复你原本的输入法。
 
 ## 当前默认行为
 
 当前 [init.lua](./init.lua) 的逻辑是：
 
-- 监听右侧 `Command`
-- 记录当前输入法
-- 切换到豆包输入法
-- 模拟双击左侧 `Option`
-- 延迟恢复到之前的输入法
+- 监听左侧 `Option`（按住说话模式）
+- 按下左 `Option` 时：记录当前输入法 → 切换到豆包输入法 → `0.3s` 后若仍按住则按下并保持左 `Command`（开始录音）
+- 松开左 `Option` 时：松开左 `Command`（结束录音）→ 延迟 `2s` 恢复到之前的输入法
 
 ## 适合谁
 
@@ -124,7 +134,7 @@ local TARGET_INPUT_SOURCE = "com.bytedance.inputmethod.doubaoime.pinyin"
 
 你可以按自己的习惯继续改：
 
-- 触发按键
-- 双击 `Option` 的时间间隔
-- 恢复原输入法的延迟
+- 触发按键（默认左 `Option`，对应 `KEYCODE_LEFT_OPTION`）
+- 按下左 `Command` 前的延迟（`CMD_PRESS_DELAY`）
+- 恢复原输入法的延迟（`RESTORE_IME_DELAY`）
 - 与你现有 Hammerspoon 配置的整合方式

--- a/init.lua
+++ b/init.lua
@@ -1,31 +1,30 @@
 -- ============================================
--- Right Command -> switch IME -> double tap Left Option
+-- 按住左 Option -> 切到豆包输入法 -> 按住左 Command（开始录音）
+-- 松开左 Option -> 松开左 Command（结束录音）-> 2s 后恢复原输入法
 -- 放到 ~/.hammerspoon/init.lua
--- 版本：保持当前可用行为，只修监听容易失效的问题
 -- ============================================
-local log = hs.logger.new("RightCmdIME", "debug")
+local log = hs.logger.new("LeftOptIME", "debug")
 local alert = hs.alert
 
 -- 目标输入法
 local TARGET_INPUT_SOURCE = "豆包输入法"
 
--- 右侧 Command 按下后，多久再执行双击左 Option（秒）
-local OPTION_PRESS_DELAY = 0.30
+-- 按住左 Option 后，多久再按下左 Command 开始录音（秒）
+local CMD_PRESS_DELAY = 0.30
 
--- 两次 Option 点击之间的间隔（秒）
-local OPTION_DOUBLE_TAP_INTERVAL = 0.18
-
--- 松开右 Command 后，延迟多久恢复原输入法（秒）
+-- 松开左 Option 后，延迟多久恢复原输入法（秒）
 local RESTORE_IME_DELAY = 2.0
 
--- 物理按键 keycode
-local KEYCODE_RIGHT_CMD = 54
+-- 触发键：左 Option 的物理 keycode
+local KEYCODE_LEFT_OPTION = 58
 
 -- 状态变量
 local previousInputSource = nil
-local rightCmdIsDown = false
-local optionPressTimer = nil
+local leftOptIsDown = false
+local cmdPressTimer = nil
 local restoreImeTimer = nil
+local cmdIsHeld = false -- 我们是否正按住合成的左 Command
+local synthesizingKey = false -- 正在发送合成事件（按下/松开左 Cmd）
 
 local function nowSource()
     local method = hs.keycodes.currentMethod()
@@ -53,26 +52,41 @@ local function debugCurrentInputState(prefix)
     log.df("[%s] currentSourceID = %s", prefix, tostring(hs.keycodes.currentSourceID()))
 end
 
-local function tapLeftOptionOnce()
-    hs.eventtap.event.newKeyEvent(hs.keycodes.map.alt, true):post()
-    hs.eventtap.event.newKeyEvent(hs.keycodes.map.alt, false):post()
-end
-
-local function doubleTapLeftOption()
-    log.df("开始模拟双击左 Option")
-    tapLeftOptionOnce()
-
-    hs.timer.doAfter(OPTION_DOUBLE_TAP_INTERVAL, function()
-        tapLeftOptionOnce()
-        log.df("已完成双击左 Option")
+-- 按下左 Command 并保持（开始录音）
+local function pressLeftCmd()
+    if cmdIsHeld then
+        log.df("左 Command 已处于按住状态，忽略重复按下")
+        return
+    end
+    synthesizingKey = true
+    hs.eventtap.event.newKeyEvent(hs.keycodes.map.cmd, true):post()
+    cmdIsHeld = true
+    log.df("已按下左 Command（开始录音）")
+    hs.timer.doAfter(0.05, function()
+        synthesizingKey = false
     end)
 end
 
-local function cancelOptionTimer()
-    if optionPressTimer then
-        optionPressTimer:stop()
-        optionPressTimer = nil
-        log.df("已取消待执行的 Option 定时器")
+-- 松开左 Command（结束录音）
+local function releaseLeftCmd()
+    if not cmdIsHeld then
+        log.df("左 Command 并未按住，无需松开")
+        return
+    end
+    synthesizingKey = true
+    hs.eventtap.event.newKeyEvent(hs.keycodes.map.cmd, false):post()
+    cmdIsHeld = false
+    log.df("已松开左 Command（结束录音）")
+    hs.timer.doAfter(0.05, function()
+        synthesizingKey = false
+    end)
+end
+
+local function cancelCmdTimer()
+    if cmdPressTimer then
+        cmdPressTimer:stop()
+        cmdPressTimer = nil
+        log.df("已取消待执行的左 Command 定时器")
     end
 end
 
@@ -88,7 +102,6 @@ local function switchToTargetIME()
     local current = nowSource()
     previousInputSource = current
 
-    -- 如果有输入法 XD
     if current == nil then
         log.df("无法识别当前输入来源，跳过记录")
     end
@@ -102,8 +115,6 @@ local function switchToTargetIME()
 
     local ok = hs.keycodes.setMethod(TARGET_INPUT_SOURCE)
     log.df("切换到目标输入法: %s, 结果: %s", TARGET_INPUT_SOURCE, tostring(ok))
-
-    -- debugCurrentInputState("after switch")
 end
 
 local function restorePreviousIME()
@@ -113,25 +124,19 @@ local function restorePreviousIME()
     end
 
     local old = previousInputSource
-
     log.df("准备恢复之前输入来源: kind=%s, value=%s", tostring(old.kind), tostring(old.value))
 
-    -- debugCurrentInputState("before restore")
     local ok = false
-
     if old.kind == "method" then
         ok = hs.keycodes.setMethod(old.value)
         log.df("恢复之前输入法 method: %s, 结果: %s", tostring(old.value), tostring(ok))
-
     elseif old.kind == "layout" then
         ok = hs.keycodes.setLayout(old.value)
         log.df("恢复之前键盘布局 layout: %s, 结果: %s", tostring(old.value), tostring(ok))
     else
-        -- 被玩坏了才可能走到这里，让我看看是哪个小伙伴这么坏！！
         log.df("未知的输入来源类型，无法恢复: %s", hs.inspect(old))
     end
 
-    -- debugCurrentInputState("after restore")
     previousInputSource = nil
 end
 
@@ -147,75 +152,74 @@ local function scheduleRestorePreviousIME()
     log.df("已安排 %.2f 秒后恢复之前输入法", RESTORE_IME_DELAY)
 end
 
-local function onRightCmdDown()
-    if rightCmdIsDown then
-        log.df("右 Command 已处于按下状态，忽略重复事件")
+local function onLeftOptDown()
+    if leftOptIsDown then
+        log.df("左 Option 已处于按下状态，忽略重复事件")
         return
     end
 
-    rightCmdIsDown = true
-    log.df("检测到右 Command 按下")
+    leftOptIsDown = true
+    log.df("检测到左 Option 按下")
 
     -- 新一轮开始时，取消上一次尚未执行的恢复动作
     cancelRestoreImeTimer()
 
     switchToTargetIME()
 
-    cancelOptionTimer()
-    optionPressTimer = hs.timer.doAfter(OPTION_PRESS_DELAY, function()
-        optionPressTimer = nil
+    cancelCmdTimer()
+    cmdPressTimer = hs.timer.doAfter(CMD_PRESS_DELAY, function()
+        cmdPressTimer = nil
 
-        if rightCmdIsDown then
-            log.df("延迟结束，右 Command 仍按着，准备双击左 Option")
-            doubleTapLeftOption()
+        if leftOptIsDown then
+            log.df("延迟结束，左 Option 仍按着，按下左 Command 开始录音")
+            pressLeftCmd()
         else
-            log.df("延迟结束时右 Command 已松开，不再双击左 Option")
+            log.df("延迟结束时左 Option 已松开，不再按下左 Command")
         end
     end)
 end
 
-local function onRightCmdUp()
-    if not rightCmdIsDown then
-        log.df("右 Command 当前并非按下状态，忽略松开事件")
+local function onLeftOptUp()
+    if not leftOptIsDown then
+        log.df("左 Option 当前并非按下状态，忽略松开事件")
         return
     end
 
-    rightCmdIsDown = false
-    log.df("检测到右 Command 松开")
+    leftOptIsDown = false
+    log.df("检测到左 Option 松开")
 
-    cancelOptionTimer()
-    doubleTapLeftOption()
+    cancelCmdTimer()
+    releaseLeftCmd()
 
     -- 延迟恢复原输入法
     scheduleRestorePreviousIME()
 end
 
--- 核心修复 1：只要检测到 rightcmd 的 flagsChanged，
--- 就根据内部状态翻转，而不是依赖 flags.cmd
-local function handleRightCmdFlagsChanged(event)
-    local keycode = event:getKeyCode()
-    local flags = event:getFlags()
-
-    if keycode ~= KEYCODE_RIGHT_CMD then
+-- 监听左 Option 的 flagsChanged：按内部状态翻转，不依赖 flags.alt 的真假
+local function handleLeftOptFlagsChanged(event)
+    -- 忽略我们自己合成的左 Command 事件
+    if synthesizingKey then
         return false
     end
 
-    -- log.df("flagsChanged: keycode=%s, cmd=%s, alt=%s, shift=%s, ctrl=%s, rightCmdIsDown=%s", tostring(keycode),
-    --     tostring(flags.cmd), tostring(flags.alt), tostring(flags.shift), tostring(flags.ctrl), tostring(rightCmdIsDown))
+    local keycode = event:getKeyCode()
+    if keycode ~= KEYCODE_LEFT_OPTION then
+        return false
+    end
 
-    if rightCmdIsDown then
-        onRightCmdUp()
+    if leftOptIsDown then
+        onLeftOptUp()
     else
-        onRightCmdDown()
+        onLeftOptDown()
     end
 
     return false
 end
 
--- 核心修复 2：避免回调异常导致 watcher 看起来“死掉”
+-- 避免回调异常导致 watcher 看起来"死掉"
 local function safeEventHandler(event)
     local ok, result = xpcall(function()
-        return handleRightCmdFlagsChanged(event)
+        return handleLeftOptFlagsChanged(event)
     end, debug.traceback)
 
     if not ok then
@@ -227,11 +231,10 @@ local function safeEventHandler(event)
 end
 
 -- 放到全局，尽量避免 reload / GC 等边缘情况
-_G.rightCmdWatcher = hs.eventtap.new({hs.eventtap.event.types.flagsChanged}, safeEventHandler)
+_G.leftOptWatcher = hs.eventtap.new({hs.eventtap.event.types.flagsChanged}, safeEventHandler)
+_G.leftOptWatcher:start()
 
-_G.rightCmdWatcher:start()
-
-alert.show("RightCmdIME 脚本已启动")
+alert.show("LeftOptIME 脚本已启动")
 log.i(string.format("目标输入法: %s", TARGET_INPUT_SOURCE))
-log.i(string.format("右 Command keycode=%d", KEYCODE_RIGHT_CMD))
+log.i(string.format("左 Option keycode=%d", KEYCODE_LEFT_OPTION))
 log.i(string.format("恢复输入法延迟=%.2f 秒", RESTORE_IME_DELAY))

--- a/init.lua
+++ b/init.lua
@@ -9,8 +9,13 @@ local alert = hs.alert
 -- 目标输入法
 local TARGET_INPUT_SOURCE = "豆包输入法"
 
--- 按住左 Option 后，多久再按下左 Command 开始录音（秒）
+-- 按住左 Option 后，多久确认为"有意录音"并切换到豆包（秒）
+-- 快速点击未达此时长则不切输入法、不录音，避免误触抖动
 local CMD_PRESS_DELAY = 0.30
+
+-- 切到豆包后，再等多久才按下左 Command（秒）
+-- 给豆包完成输入法切换的时间，避免 Command 先于切换到达导致录音不触发
+local SWITCH_TO_CMD_DELAY = 0.10
 
 -- 松开左 Option 后，延迟多久恢复原输入法（秒）
 local RESTORE_IME_DELAY = 2.0
@@ -164,18 +169,28 @@ local function onLeftOptDown()
     -- 新一轮开始时，取消上一次尚未执行的恢复动作
     cancelRestoreImeTimer()
 
-    switchToTargetIME()
-
+    -- 延迟切豆包：只有按住超过 CMD_PRESS_DELAY 才真正切换输入法并开始录音，
+    -- 快速点击（误触）不会动输入法，零抖动
     cancelCmdTimer()
     cmdPressTimer = hs.timer.doAfter(CMD_PRESS_DELAY, function()
         cmdPressTimer = nil
 
-        if leftOptIsDown then
-            log.df("延迟结束，左 Option 仍按着，按下左 Command 开始录音")
-            pressLeftCmd()
-        else
-            log.df("延迟结束时左 Option 已松开，不再按下左 Command")
+        if not leftOptIsDown then
+            log.df("延迟结束时左 Option 已松开（快速点击），不切换输入法、不录音")
+            return
         end
+
+        log.df("延迟结束，左 Option 仍按着，切换到豆包并准备录音")
+        switchToTargetIME()
+
+        -- 切完输入法再稍候按下 Command，给豆包完成切换的时间
+        hs.timer.doAfter(SWITCH_TO_CMD_DELAY, function()
+            if leftOptIsDown then
+                pressLeftCmd()
+            else
+                log.df("切换后左 Option 已松开，不再按下左 Command")
+            end
+        end)
     end)
 end
 
@@ -188,11 +203,30 @@ local function onLeftOptUp()
     leftOptIsDown = false
     log.df("检测到左 Option 松开")
 
+    -- 松开前的状态判断：
+    -- wasRecording：是否真的进入了录音（左 Command 被按住）
+    -- switchedIME：是否已经切到过豆包（switchToTargetIME 记录了原输入法）
+    local wasRecording = cmdIsHeld
+    local switchedIME = previousInputSource ~= nil
+
     cancelCmdTimer()
     releaseLeftCmd()
 
-    -- 延迟恢复原输入法
-    scheduleRestorePreviousIME()
+    if not switchedIME then
+        -- 快速点击：定时器在切豆包前就被取消，输入法从未改动，什么都不用做
+        log.df("快速点击，未切换过输入法，无需恢复")
+        return
+    end
+
+    if wasRecording then
+        -- 已进入录音：延迟恢复，给豆包时间把识别结果上屏
+        scheduleRestorePreviousIME()
+    else
+        -- 切了豆包但还没按下 Command 就松开了：立即切回原输入法，不傻等
+        log.df("已切豆包但未进入录音便松开，立即恢复原输入法")
+        cancelRestoreImeTimer()
+        restorePreviousIME()
+    end
 end
 
 -- 监听左 Option 的 flagsChanged：按内部状态翻转，不依赖 flags.alt 的真假


### PR DESCRIPTION
## 关联 Issue

相关 Issue：#4（关联，不自动关闭，是否解决由维护者判断）

> Issue #4 反馈：豆包 V0.9.0 默认改用**右 Option** 作语音开关，导致脚本里的左 Option 无法跑通。
>
> 本 PR 不再依赖豆包默认的 Option 开关键（无论左/右），而是改用可自定义的「长按模式」快捷键（左 ⌘）来对接语音输入，从根本上解决"跟随豆包默认键变动而失效"的问题。基于豆包 0.9.1 验证。

## 改动概述

将触发方式从 **「按住右 Command + 双击左 Option」** 改为 **「按住左 Option」按住说话** 模式，直接对接豆包输入法语音输入的「长按模式」。

### 为什么改

- 原方案监听右 Command + 模拟双击左 Option，依赖"双击 Option 唤起语音"。在新版豆包上，模拟的双击/单击 Option 只能弹出语音界面但不真正开始录音。
- 新版豆包语音输入提供「长按模式：按住说话，松手结束」，其快捷键可绑定为 **左 ⌘（左 Command）**。本 PR 改为模拟"按住左 Command"来对接该长按模式，行为更稳定、语义更直接。
- 部分用户没有右 Command 键（或其 keycode 不为 54），左 Option 更通用。

## 新逻辑

| 时机 | 动作 |
|------|------|
| 按住**左 Option**（keycode 58） | 记录当前输入法 → 切到豆包 → `0.3s` 后若仍按住则**按下并保持左 Command**（开始录音） |
| 松开**左 Option** | **松开左 Command**（结束录音）→ `2s` 后恢复原输入法 |

实现要点：
- 监听左 Option 的 `flagsChanged`，按内部状态翻转判断按下/松开（不依赖 `flags.alt` 真假）。
- 左 Command 为**真按住**（按下后保持，跟随左 Option 生命周期），而非瞬时点击。
- 过滤脚本自身合成的左 Command 事件，避免误判为触发键。
- 保留原脚本的 `xpcall` 容错与全局 watcher 防 GC 设计。

## 适配版本与前置配置

- 适配豆包输入法 macOS 版本 **0.9.1**。
- 使用前需在豆包输入法 → `语音输入` → 「快捷键」中，确认 **长按模式（按住说话，松手结束）** 的快捷键绑定为 **左 ⌘**。

## 文档

- README 更新「安装后怎么用」「当前默认行为」「可自定义项」为新逻辑。
- 新增「前置配置：豆包语音输入长按模式」章节，说明 0.9.1 版本要求及左 ⌘ 绑定。

## 测试计划

- [ ] Hammerspoon Reload Config 后，按住左 Option：确认切到豆包输入法
- [ ] 持续按住 ≥0.3s：确认左 Command 被按下并开始录音
- [ ] 说话后松开左 Option：确认录音结束、文字上屏
- [ ] 确认 2s 后恢复到原输入法
- [ ] 确认单独/正常使用左 Option 组合键不被异常拦截

🤖 Generated with [Claude Code](https://claude.com/claude-code)

